### PR TITLE
fix: 디테일 화면 검정색 재생 수정

### DIFF
--- a/feature/main/src/main/java/com/example/main/detail/VideoDetailViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/detail/VideoDetailViewModel.kt
@@ -53,6 +53,8 @@ class VideoDetailViewModel @Inject constructor(
 
     fun setVideo(video: Video) {
         _video.value = video
+        // 새 Surface에 첫 프레임이 렌더링될 때까지 썸네일 유지
+        playerManager.resetFirstFrame()
         // 비디오가 이미 프리뷰에서 재생 중이면 음소거 해제하고 재생
         if (playerManager.playbackState.value.videoId == video.id) {
             playerManager.setMuted(false)

--- a/feature/main/src/main/java/com/example/main/detail/VideoPlayerWithControls.kt
+++ b/feature/main/src/main/java/com/example/main/detail/VideoPlayerWithControls.kt
@@ -118,9 +118,10 @@ fun VideoPlayerWithControls(
             )
         }
 
-        // 썸네일 (재생 시작 전까지 표시, 재생 시작하면 fade out)
+        // 썸네일 (첫 프레임이 실제 렌더링될 때까지 표시, 그 후 fade out)
         val isActuallyPlaying = playbackState.isPlaying &&
-                playbackState.playbackState == PlaybackState.STATE_READY
+                playbackState.playbackState == PlaybackState.STATE_READY &&
+                playbackState.isFirstFrameRendered
 
         AnimatedVisibility(
             visible = !isActuallyPlaying,


### PR DESCRIPTION
## Summary
- 디테일 화면 진입 시 간혹 검정색 화면만 보이는 문제 수정 (Closes #4)
- 리스트→디테일 전환 시 `resetFirstFrame()`으로 새 Surface 렌더링 대기
- `isActuallyPlaying` 조건에 `isFirstFrameRendered` 추가하여 첫 프레임 렌더링 확인 후 썸네일 fade out

## Root Cause
리스트 프리뷰에서 `isFirstFrameRendered=true`인 상태로 디테일 진입 시, 새 PlayerView Surface가 아직 렌더링 전인데 썸네일이 즉시 사라져 검정색이 노출됨

## Changed Files
- `VideoDetailViewModel.kt` - `setVideo()`에 `resetFirstFrame()` 추가
- `VideoPlayerWithControls.kt` - `isActuallyPlaying`에 `isFirstFrameRendered` 조건 추가

## Test plan
- [ ] 메인 리스트에서 비디오 클릭 시 디테일 화면에 검정색 없이 썸네일→재생 전환 확인
- [ ] 빠르게 반복 진입/퇴장 시에도 검정색 화면 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)