### PR TITLE
fix: SeekBar 튕김 현상 수정

### DIFF
--- a/core/player/src/main/java/com/example/player/VideoPlayerManager.kt
+++ b/core/player/src/main/java/com/example/player/VideoPlayerManager.kt
@@ -85,6 +85,10 @@ class VideoPlayerManager @Inject constructor(
 
     fun seekTo(positionMs: Long) {
         exoPlayer?.seekTo(positionMs)
+        // Seek 후 즉시 position 반영 (progress tracker 200ms 대기 없이)
+        _playbackState.value = _playbackState.value.copy(
+            currentPosition = positionMs
+        )
     }
 
     fun setMuted(muted: Boolean) {


### PR DESCRIPTION
## Summary
- SeekBar 프로그레스바가 일시적으로 이전 위치로 튀었다가 돌아오는 현상 수정 (Closes #5)
- `seekTo()`에서 즉시 `currentPosition` 반영하여 200ms 진행 추적 지연으로 인한 bounce 제거
- `isUserDragging`/`isSeeking` 상태 분리로 seek 대기 중에도 사용자 위치 유지

## Changed Files
- `VideoPlayerManager.kt` - `seekTo()`에서 즉시 상태 업데이트
- `VideoPlayerWithControls.kt` - Slider 상태 관리 개선 (드래그/seek 대기 분리)

## Test plan
- [ ] SeekBar 드래그 후 놓았을 때 이전 위치로 튀지 않는지 확인
- [ ] 빠르게 여러 번 seek 시에도 안정적인지 확인
- [ ] seek 후 버퍼링 발생 시 로딩 인디케이터 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)