### PR TITLE
fix: 앱 백그라운드 진입 시 비디오 중지 및 복귀 시 재생

### DIFF
--- a/app/src/main/java/com/example/grensilvideolist/MainActivity.kt
+++ b/app/src/main/java/com/example/grensilvideolist/MainActivity.kt
@@ -17,6 +17,22 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var videoPlayerManager: VideoPlayerManager
 
+    private var wasPlayingBeforeBackground = false
+
+    override fun onStop() {
+        super.onStop()
+        wasPlayingBeforeBackground = videoPlayerManager.playbackState.value.isPlaying
+        videoPlayerManager.pause()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (wasPlayingBeforeBackground) {
+            videoPlayerManager.play()
+            wasPlayingBeforeBackground = false
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/feature/main/src/main/java/com/example/main/HomeScreen.kt
+++ b/feature/main/src/main/java/com/example/main/HomeScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.collectAsState
@@ -20,9 +19,6 @@ import com.example.domain.model.Photo
 import com.example.main.component.ImagePreviewDialog
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavHostController
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.example.domain.model.MediaItem
@@ -115,26 +111,6 @@ fun HomeScreen(
                     } ?: viewModel.onCenterVideoChanged(null)
                 }
             }
-    }
-
-    // 라이프사이클 관리
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            when (event) {
-                Lifecycle.Event.ON_PAUSE -> viewModel.videoPlayerManager.pause()
-                Lifecycle.Event.ON_RESUME -> {
-                    if (currentPlayingVideoId != null) {
-                        viewModel.videoPlayerManager.play()
-                    }
-                }
-                else -> {}
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-        }
     }
 
     Scaffold(


### PR DESCRIPTION
## Summary
- 앱 백그라운드 진입 시 비디오 중지, 복귀 시 이전 지점부터 재생 (Closes #6)
- MainActivity `onStop/onStart`에서 통합 처리하여 모든 화면에서 동작
- HomeScreen의 중복 라이프사이클 옵저버 제거 (화면 전환 시 불필요한 pause 방지)

## Changed Files
- `MainActivity.kt` - `onStop/onStart` 백그라운드 처리 추가
- `HomeScreen.kt` - 중복 라이프사이클 옵저버 제거

## Test plan
- [ ] 메인 리스트에서 홈 버튼 → 비디오 중지 → 복귀 시 이어 재생
- [ ] 디테일 화면에서 홈 버튼 → 비디오 중지 → 복귀 시 이어 재생
- [ ] 화면 전환(리스트↔디테일) 시 불필요한 pause 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)