### PR TITLE
fix: 디테일 화면 검정색 재생 수정 (#4)

### DIFF
--- a/feature/main/src/main/java/com/example/main/detail/VideoDetailViewModel.kt
+++ b/feature/main/src/main/java/com/example/main/detail/VideoDetailViewModel.kt
@@ -53,20 +53,8 @@ class VideoDetailViewModel @Inject constructor(
 
     fun setVideo(video: Video) {
         _video.value = video
-        // 비디오가 이미 프리뷰에서 재생 중이면 음소거 해제하고 재생
-        if (playerManager.playbackState.value.videoId == video.id) {
-            playerManager.setMuted(false)
-            playerManager.play()  // 확실히 재생 시작
-        } else {
-            // 새로운 비디오면 처음부터 재생
-            val url = video.videoFiles.maxByOrNull { it.width * it.height }?.link ?: return
-            playerManager.prepare(
-                videoId = video.id,
-                url = url,
-                muted = false,
-                autoPlay = true
-            )
-        }
+        val url = video.videoFiles.maxByOrNull { it.width * it.height }?.link ?: return
+        playerManager.prepareForDetail(video.id, url)
     }
 
     fun togglePlayPause() {

--- a/feature/main/src/main/java/com/example/main/detail/VideoPlayerWithControls.kt
+++ b/feature/main/src/main/java/com/example/main/detail/VideoPlayerWithControls.kt
@@ -52,6 +52,7 @@ import androidx.media3.ui.PlayerView
 import coil.compose.AsyncImage
 import com.example.designsystem.theme.Teal
 import com.example.designsystem.util.TimeFormatUtils
+import com.example.main.component.VideoProgressBar
 import com.example.player.PlaybackState
 import kotlin.math.abs
 import kotlinx.coroutines.delay
@@ -132,7 +133,8 @@ fun VideoPlayerWithControls(
 
         // 썸네일 (재생 시작 전까지 표시, 재생 시작하면 fade out)
         val isActuallyPlaying = playbackState.isPlaying &&
-                playbackState.playbackState == PlaybackState.STATE_READY
+                playbackState.playbackState == PlaybackState.STATE_READY &&
+                playbackState.isFirstFrameRendered
 
         AnimatedVisibility(
             visible = !isActuallyPlaying,
@@ -155,6 +157,16 @@ fun VideoPlayerWithControls(
                     .size(48.dp)
                     .align(Alignment.Center),
                 color = Teal
+            )
+        }
+
+        // 항상 표시되는 프로그레스바 (컨트롤 숨겨져도 보임)
+        if (!showControls && isActuallyPlaying) {
+            VideoProgressBar(
+                progress = playbackState.progress,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
             )
         }
 


### PR DESCRIPTION
## Summary
- 디테일 진입 시 검정 화면으로 재생되는 버그 수정
- Surface 충돌과 스크롤 debounce 레이스 컨디션 두 가지 근본 원인 해결
- 디테일 프로그레스바 항상 표시되도록 개선

## 변경 내용
| 파일 | 변경 |
|------|------|
| `VideoPlayerManager.kt` | `prepareForTransition()` + `prepareForDetail()` 추가 |
| `HomeViewModel.kt` | 스크롤 debounce 레이스 컨디션 차단 (500ms 가드) |
| `VideoDetailViewModel.kt` | `setVideo()` 단순화 - 항상 fresh prepare |
| `VideoPlayerWithControls.kt` | `isFirstFrameRendered` 체크 + 항상 보이는 프로그레스바 |

## 근본 원인
1. **Surface 충돌**: 리스트의 `VideoPreviewSurface`가 비동기 Dispose 시 `playerView.player = null` 호출 → 디테일의 새 Surface 연결 방해
2. **스크롤 debounce 레이스 컨디션**: 디테일 진입 후 300ms에 스크롤 debounce 발동 → `prepare()`가 `prepareForDetail()`을 덮어씀

## Test plan
- [x] 프리뷰 재생 → 빠르게 스크롤 → 바로 디테일 진입 → 비디오 재생 확인
- [x] 프리뷰 재생 중인 비디오 클릭 → 디테일에서 이어서 재생 확인
- [x] 프리뷰 없는 비디오 클릭 → 디테일에서 처음부터 재생 확인
- [x] 디테일에서 뒤로가기 → 리스트 프리뷰 정상 동작 확인
- [x] 컨트롤 숨겨져도 프로그레스바 표시 확인

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)